### PR TITLE
nsc-events-fullstack_sprint#25_issue#4_Profile page returning hardcoded (dummy) event data instead of actual event details

### DIFF
--- a/nsc-events-nestjs/src/activity/activity.module.ts
+++ b/nsc-events-nestjs/src/activity/activity.module.ts
@@ -10,6 +10,6 @@ import { S3Service } from '../activity/services/activity/s3.service';
   imports: [AuthModule, TypeOrmModule.forFeature([Activity])],
   controllers: [ActivityController],
   providers: [ActivityService, S3Service],
-  exports: [TypeOrmModule],
+  exports: [TypeOrmModule, ActivityService],
 })
 export class ActivityModule {}

--- a/nsc-events-nestjs/src/event-registration/controllers/event-registration.controller.ts
+++ b/nsc-events-nestjs/src/event-registration/controllers/event-registration.controller.ts
@@ -83,7 +83,7 @@ export class EventRegistrationController {
       );
     // Always return counts for all users
     const count = registrations.length;
-    // Since we don't have an iAnonymous field, we'll set anonymouseCount to 0
+    // Since we don't have an isAnonymous field, we'll set anonymousCount to 0
     const anonymousCount = 0;
 
     // Generate attendee names from firstName and lastName
@@ -158,7 +158,7 @@ export class EventRegistrationController {
     return { isRegistered };
   }
 
-  // Check if user is attending an event
+  // Check if user is attending an event (alias for frontend compatability)
   @UseGuards(JwtAuthGuard)
   @Get('is-attending/:activityId/:userId')
   async isUserAttending(
@@ -193,7 +193,7 @@ export class EventRegistrationController {
     return this.registrationService.markAttendance(id, body.isAttended);
   }
 
-  // Get attendees for an event (who actually attended)
+  // Get attendees for an event
   @Get('attendees/:activityId')
   async getAttendeesForEvent(
     @Param('activityId') activityId: string,


### PR DESCRIPTION
<!-- Please use the following format for the title:-->

<!-- Example: appdev-repo_88_888_example-pr-name -->

<!-- Please fill out the following: -->
## Summary & Changes 📃
- **Resolves:** `#4`
 
- **Summary:** (Briefly describe what this PR does)
      On the Profile Page, the list of attended events displays incorrect (dummy) data. This issue originates on the backend controller, **geteventsforuser** method, which currently returns hardcoded event objects instead of fetching real data by querying the **activityservice** to receive actual event information by **activityid**. 

<img width="1122" height="945" alt="499567171-0c2b8037-1e35-4e3d-a5e4-4022058489b0" src="https://github.com/user-attachments/assets/5a362f78-dca0-48a9-807d-49a27d70b849" />

<img width="1980" height="1117" alt="499571155-e9d4a009-b3bb-45be-aceb-5192b891bcae" src="https://github.com/user-attachments/assets/63a96ce0-71f8-4ee1-8ada-d1cb2da85208" />


- **Changes:**
I have imported and injected ActivityService to access event detail. I also have modified getEventsForUser to return actual event information, instead of the previous hardcoded data. This should allow the Profile Page to receive actual event date data instead of just hardcoded data.


## Screenshots / Visual Aids 🔎
<sub><i>📌 **Required for:** UI changes, layout updates, or bug fixes.</i></sub>

<details>
  <summary> Expand ⬇️ </summary>

https://github.com/user-attachments/assets/f17b1a74-7c70-49d5-b16f-ef217c395c99


  <!-- add GIFs/Screenshots/Videos/Diagrams here -->
</details>


## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: Run "npm run start" in the nsc-events-nestjs folder to start the backend
   - Step 2: Run "npm run dev" in the nsc-events-nextjs folder to start the frontend
   - Step 3: Make sure that you are logged in as an admin user
   - Step 4: Make sure that you at least 2 events made with dates set.
   - Step 5: Go to the localhost:8080/profile page and make sure that the events and 
    their actual dates and details are set.
2. **Expected Behavior:** You should see the real-time event data in there instead of the previous hardcoded data.



## Checklist ✅

- [X] I have **tested** this PR **locally** and it works as expected.
- [X] This PR **resolves an issue** (`Resolves #issue-number`).
- [X] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [X] **Squash commits** and enable **auto-merge** if approved.

