### PR TITLE
nsc-events-fullstack_27_94_archive-events-search-and-fixes

### DIFF
--- a/nsc-events-nestjs/src/activity/controllers/activity/activity.controller.spec.ts
+++ b/nsc-events-nestjs/src/activity/controllers/activity/activity.controller.spec.ts
@@ -105,7 +105,12 @@ describe('ActivityController', () => {
         expectedActivities,
       );
 
-      const result = await controller.getAllActivities('2', '20', undefined, 'false');
+      const result = await controller.getAllActivities(
+        '2',
+        '20',
+        undefined,
+        'false',
+      );
 
       expect(result).toEqual(expectedActivities);
       expect(mockActivityService.getAllActivities).toHaveBeenCalledWith({
@@ -191,7 +196,13 @@ describe('ActivityController', () => {
         expectedActivities,
       );
 
-      const result = await controller.getAllActivities('1', '12', undefined, 'false', '');
+      const result = await controller.getAllActivities(
+        '1',
+        '12',
+        undefined,
+        'false',
+        '',
+      );
 
       expect(result).toEqual(expectedActivities);
       expect(mockActivityService.getAllActivities).toHaveBeenCalledWith({
@@ -208,7 +219,12 @@ describe('ActivityController', () => {
         archivedActivity,
       ]);
 
-      const result = await controller.getAllActivities('1', '12', undefined, 'true');
+      const result = await controller.getAllActivities(
+        '1',
+        '12',
+        undefined,
+        'true',
+      );
 
       expect(result).toEqual([archivedActivity]);
       expect(mockActivityService.getAllActivities).toHaveBeenCalledWith({

--- a/nsc-events-nextjs/app/archived-events/page.tsx
+++ b/nsc-events-nextjs/app/archived-events/page.tsx
@@ -1,193 +1,470 @@
 'use client';
 
 import useAuth from "@/hooks/useAuth";
-import { Button, Checkbox, Container, Grid, IconButton, Menu, MenuItem, Pagination, Paper, Stack, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TextField, Typography, useMediaQuery, useTheme } from "@mui/material";
+import {
+  Button,
+  Container,
+  Grid,
+  IconButton,
+  Menu,
+  MenuItem,
+  Pagination,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+  useMediaQuery,
+  useTheme,
+  CircularProgress,
+  Box,
+  InputAdornment
+} from "@mui/material";
 import MoreVertIcon from '@mui/icons-material/MoreVert';
-import React, { useEffect, useMemo, useState } from "react";
-import { useArchivedEvents } from "@/utility/queries";
+import SearchIcon from '@mui/icons-material/Search';
+import ClearIcon from '@mui/icons-material/Clear';
+import React, { useEffect, useState, useCallback } from "react";
 import UnauthorizedPageMessage from "../../components/UnauthorizedPageMessage";
 import { ActivityDatabase } from "@/models/activityDatabase";
 import EventCard from "../../components/EventCard";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import ArchiveDialog from "@/components/ArchiveDialog";
 
 const ArchivedEvents = () => {
-
     const { isAuth, user } = useAuth();
+    const router = useRouter();
     const [events, setEvents] = useState<ActivityDatabase[]>([]);
+    const [loading, setLoading] = useState(false);
     const [page, setPage] = useState(1);
-    const [hasReachedLastPage, setHasReachedLastPage] = useState(false);
-    const { data } = useArchivedEvents(page, true);
+    const [totalPages, setTotalPages] = useState(1);
+    const [hasMore, setHasMore] = useState(true);
+
+    // Filter states
+    const [searchQuery, setSearchQuery] = useState('');
+    const [locationFilter, setLocationFilter] = useState('');
+    const [hostFilter, setHostFilter] = useState('');
+    const [startDateFilter, setStartDateFilter] = useState('');
+    const [endDateFilter, setEndDateFilter] = useState('');
+
+    // Debounced search
+    const [debouncedSearch, setDebouncedSearch] = useState('');
+
+    // Menu state
+    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const [selectedEvent, setSelectedEvent] = useState<ActivityDatabase | null>(null);
+    const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
+
     const theme = useTheme();
     const isDarkMode = theme.palette.mode === 'dark';
-    // const memoizedTheme = useMemo(() => theme, [theme.palette.mode]); // this is an idea for dark mode bug fix 
     const isMobile = useMediaQuery(theme.breakpoints.between('xs', 'sm'));
-    const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-    const open = Boolean(anchorEl);
-    const ITEM_HEIGHT = 48;
+    const EVENTS_PER_PAGE = 12;
 
-    const options = [
-        "place",
-        "holder",
-        "menu",
-        "options"
-    ]
-    
-    const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-        setAnchorEl(event.currentTarget);
+    // Debounce search input
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            setDebouncedSearch(searchQuery);
+            setPage(1); // Reset to first page on search
+        }, 500);
+
+        return () => clearTimeout(timer);
+    }, [searchQuery]);
+
+    // Fetch events with filters
+    const fetchEvents = useCallback(async () => {
+        setLoading(true);
+        try {
+            const apiUrl = process.env.NSC_EVENTS_PUBLIC_API_URL;
+            const params = new URLSearchParams({
+                page: String(page),
+                numEvents: String(EVENTS_PER_PAGE),
+                isArchived: 'true',
+            });
+
+            // Add filters if they exist
+            if (locationFilter) {
+                params.append('location', locationFilter);
+            }
+            if (hostFilter) {
+                params.append('host', hostFilter);
+            }
+            if (startDateFilter) {
+                params.append('startDate', startDateFilter);
+            }
+            if (endDateFilter) {
+                params.append('endDate', endDateFilter);
+            }
+
+            // Use search endpoint if search query exists
+            let url = `${apiUrl}/events`;
+            if (debouncedSearch) {
+                url = `${apiUrl}/events/search`;
+                params.set('q', debouncedSearch);
+            }
+
+            const response = await fetch(`${url}?${params.toString()}`);
+            const data = await response.json();
+
+            if (isMobile) {
+                // Infinite scroll for mobile
+                if (page === 1) {
+                    setEvents(data);
+                } else {
+                    setEvents(prev => [...prev, ...data]);
+                }
+                setHasMore(data.length === EVENTS_PER_PAGE);
+            } else {
+                // Pagination for desktop
+                setEvents(data);
+                // Calculate total pages (this is approximate since we don't have total count)
+                if (data.length < EVENTS_PER_PAGE) {
+                    setTotalPages(page);
+                } else {
+                    setTotalPages(page + 1);
+                }
+            }
+        } catch (error) {
+            console.error('Error fetching archived events:', error);
+        } finally {
+            setLoading(false);
+        }
+    }, [page, debouncedSearch, locationFilter, hostFilter, startDateFilter, endDateFilter, isMobile]);
+
+    useEffect(() => {
+        if (isAuth && (user?.role === 'admin' || user?.role === 'creator')) {
+            fetchEvents();
+        }
+    }, [isAuth, user, fetchEvents]);
+
+    const handlePageChange = (_event: React.ChangeEvent<unknown>, value: number) => {
+        setPage(value);
+        window.scrollTo({ top: 0, behavior: 'smooth' });
     };
-    const handleClose = () => {
+
+    const handleLoadMore = () => {
+        setPage(prev => prev + 1);
+    };
+
+    const handleMenuClick = (event: React.MouseEvent<HTMLElement>, eventData: ActivityDatabase) => {
+        setAnchorEl(event.currentTarget);
+        setSelectedEvent(eventData);
+    };
+
+    const handleMenuClose = () => {
         setAnchorEl(null);
     };
 
-    const handleChange = (
-        _event: React.ChangeEvent<unknown>, value: number
-    ) => {
-        setPage(value);
-    };
-
-    useEffect(() => {
-        if (data) {
-            if (isMobile) {
-                setEvents((prevEvents) => [...prevEvents, ...data]);
-                setHasReachedLastPage(data.length < 5);
-            } else {
-                setEvents(data);
-            }
+    const handleUnarchive = () => {
+        if (selectedEvent) {
+            setArchiveDialogOpen(true);
         }
-    }, [data, isMobile]);
-
-    const handleLoadMoreEvents = () => {
-        setPage((page) => page + 1);
+        handleMenuClose();
     };
 
-    if (isAuth && (user?.role === 'admin' || user?.role === 'creator')) {
-        if (isMobile) {
-            return (
-                <Container maxWidth={false}>
-                    <Typography fontSize={"1.75rem"} textAlign={"center"} padding={"1rem"} marginTop={"1rem"} marginBottom={"1rem"}>
-                        Archived Events
-                    </Typography>
-                    <Grid container gap={4}>
-                        <TextField id="outlined-search" label="Search field" type="search" defaultValue="Event Name" helperText="Search by event name" />
-                        <TextField id="outlined-search" label="Search field" type="search" defaultValue="Date" helperText="Search by event date" />
-                        <TextField id="outlined-search" label="Search field" type="search" defaultValue="Host" helperText="Search by event host" />
-                    </Grid>
-                    <Grid container direction={"column"} spacing={1} alignItems={"center"} justifyItems={"center"} marginTop={"2rem"}>
-                        {events.map((event: ActivityDatabase) => (
-                            <Grid key={event.id}>
-                                <Link key={event.id} href={
-                                    {
+    const handleViewDetails = () => {
+        if (selectedEvent) {
+            router.push(`/event-detail?id=${selectedEvent.id}&from=archived`);
+        }
+        handleMenuClose();
+    };
+
+    const clearFilters = () => {
+        setSearchQuery('');
+        setLocationFilter('');
+        setHostFilter('');
+        setStartDateFilter('');
+        setEndDateFilter('');
+        setPage(1);
+    };
+
+    const hasActiveFilters = searchQuery || locationFilter || hostFilter || startDateFilter || endDateFilter;
+
+    if (!isAuth || (user?.role !== 'admin' && user?.role !== 'creator')) {
+        return <UnauthorizedPageMessage />;
+    }
+
+    if (isMobile) {
+        return (
+            <Container maxWidth={false} sx={{ py: 3 }}>
+                <Typography fontSize="1.75rem" textAlign="center" padding="1rem" marginBottom="1rem">
+                    Archived Events
+                </Typography>
+
+                {/* Search and Filters */}
+                <Stack spacing={2} mb={3}>
+                    <TextField
+                        fullWidth
+                        placeholder="Search events..."
+                        value={searchQuery}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchQuery(e.target.value)}
+                        InputProps={{
+                            startAdornment: (
+                                <InputAdornment position="start">
+                                    <SearchIcon />
+                                </InputAdornment>
+                            ),
+                            endAdornment: searchQuery && (
+                                <InputAdornment position="end">
+                                    <IconButton size="small" onClick={() => setSearchQuery('')}>
+                                        <ClearIcon />
+                                    </IconButton>
+                                </InputAdornment>
+                            ),
+                        }}
+                    />
+                    <TextField
+                        fullWidth
+                        placeholder="Filter by location"
+                        value={locationFilter}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setLocationFilter(e.target.value)}
+                    />
+                    <TextField
+                        fullWidth
+                        placeholder="Filter by host"
+                        value={hostFilter}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setHostFilter(e.target.value)}
+                    />
+                    {hasActiveFilters && (
+                        <Button variant="outlined" onClick={clearFilters} startIcon={<ClearIcon />}>
+                            Clear Filters
+                        </Button>
+                    )}
+                </Stack>
+
+                {/* Events List */}
+                {loading && page === 1 ? (
+                    <Box display="flex" justifyContent="center" py={4}>
+                        <CircularProgress />
+                    </Box>
+                ) : (
+                    <Grid container direction="column" spacing={2} alignItems="center">
+                        {events.map((event) => (
+                            <Grid key={event.id} item>
+                                <Link
+                                    href={{
                                         pathname: "/event-detail",
-                                        query: {
-                                            id: event.id,
-                                            events: JSON.stringify(events.map(e => e.id)),
-                                            from: 'archived',
-                                            page: page
-                                        },
-                                    }
-                                }>
-                                    <EventCard event={event}/>
+                                        query: { id: event.id, from: 'archived' },
+                                    }}
+                                >
+                                    <EventCard event={event} />
                                 </Link>
                             </Grid>
                         ))}
-                    {!hasReachedLastPage && (
-                        <Button onClick={handleLoadMoreEvents} type='button' variant="contained" color="primary" style={{ textTransform: "none", margin: '1em auto' }}>
-                            Load more events
-                        </Button>
-                    )}
+                        {events.length === 0 && !loading && (
+                            <Typography variant="body1" color="text.secondary" textAlign="center" py={4}>
+                                No archived events found
+                            </Typography>
+                        )}
+                        {hasMore && events.length > 0 && (
+                            <Button
+                                onClick={handleLoadMore}
+                                variant="contained"
+                                disabled={loading}
+                                sx={{ mt: 2 }}
+                            >
+                                {loading ? <CircularProgress size={24} /> : 'Load More'}
+                            </Button>
+                        )}
                     </Grid>
-                </Container>
-            );
-        } else {
-        return (
-            <Grid container direction={"column"} sx={{ backgroundColor: (theme) => theme.palette.background.default, margin: "2rem", }}> 
-                <Typography variant="h4" sx={{ padding: "2rem" }} alignSelf={"center"} display={"flex"}>Archived Events</Typography>
-                <Grid container gap={4} alignSelf={"center"}>
-                    <TextField id="outlined-search" label="Search field" type="search" defaultValue="Event Name" helperText="Search by event name" />
-                    <TextField id="outlined-search" label="Search field" type="search" defaultValue="Date" helperText="Search by event date" />
-                    <TextField id="outlined-search" label="Search field" type="search" defaultValue="Host" helperText="Search by event host" />
+                )}
+            </Container>
+        );
+    }
+
+    // Desktop view
+    return (
+        <Container maxWidth="xl" sx={{ py: 4 }}>
+            <Typography variant="h4" textAlign="center" mb={4}>
+                Archived Events
+            </Typography>
+
+            {/* Search and Filters */}
+            <Paper elevation={2} sx={{ p: 3, mb: 3 }}>
+                <Grid container spacing={2}>
+                    <Grid item xs={12} md={6}>
+                        <TextField
+                            fullWidth
+                            label="Search"
+                            placeholder="Search by title, description, location, or host..."
+                            value={searchQuery}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchQuery(e.target.value)}
+                            InputProps={{
+                                startAdornment: (
+                                    <InputAdornment position="start">
+                                        <SearchIcon />
+                                    </InputAdornment>
+                                ),
+                                endAdornment: searchQuery && (
+                                    <InputAdornment position="end">
+                                        <IconButton size="small" onClick={() => setSearchQuery('')}>
+                                            <ClearIcon />
+                                        </IconButton>
+                                    </InputAdornment>
+                                ),
+                            }}
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={3}>
+                        <TextField
+                            fullWidth
+                            label="Location"
+                            placeholder="Filter by location"
+                            value={locationFilter}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setLocationFilter(e.target.value)}
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={3}>
+                        <TextField
+                            fullWidth
+                            label="Host"
+                            placeholder="Filter by host"
+                            value={hostFilter}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setHostFilter(e.target.value)}
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <TextField
+                            fullWidth
+                            label="Start Date (From)"
+                            type="date"
+                            value={startDateFilter}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setStartDateFilter(e.target.value)}
+                            InputLabelProps={{ shrink: true }}
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <TextField
+                            fullWidth
+                            label="End Date (To)"
+                            type="date"
+                            value={endDateFilter}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEndDateFilter(e.target.value)}
+                            InputLabelProps={{ shrink: true }}
+                        />
+                    </Grid>
+                    {hasActiveFilters && (
+                        <Grid item xs={12}>
+                            <Button variant="outlined" onClick={clearFilters} startIcon={<ClearIcon />}>
+                                Clear All Filters
+                            </Button>
+                        </Grid>
+                    )}
                 </Grid>
-                <Grid container sx={{ padding: "2rem" }} display={"flex"}>
-                </Grid>
-                <Grid container sx={{ padding: "2rem" }} display={"flex"}>
+            </Paper>
+
+            {/* Events Table */}
+            {loading ? (
+                <Box display="flex" justifyContent="center" py={4}>
+                    <CircularProgress />
+                </Box>
+            ) : (
+                <>
                     <TableContainer component={Paper}>
                         <Table stickyHeader>
                             <TableHead>
                                 <TableRow>
-                                    <TableCell sx={{ backgroundColor: isDarkMode ? '#333' : 'inherit' }}>
+                                    <TableCell sx={{ backgroundColor: isDarkMode ? '#333' : 'inherit', color: isDarkMode ? 'white' : 'inherit', fontWeight: 'bold' }}>
+                                        Event Title
                                     </TableCell>
-                                    <TableCell sx={{ backgroundColor: isDarkMode ? '#333' : 'inherit', color: isDarkMode ? 'white' : 'inherit', fontWeight: 'bold' }}>Event Title</TableCell>
-                                    <TableCell sx={{ backgroundColor: isDarkMode ? '#333' : 'inherit', color: isDarkMode ? 'white' : 'inherit', fontWeight: 'bold' }}>Date</TableCell>
-                                    <TableCell sx={{ backgroundColor: isDarkMode ? '#333' : 'inherit', color: isDarkMode ? 'white' : 'inherit', fontWeight: 'bold' }}>Location</TableCell>
-                                    <TableCell sx={{ backgroundColor: isDarkMode ? '#333' : 'inherit', color: isDarkMode ? 'white' : 'inherit', fontWeight: 'bold' }}>Event Contact</TableCell>
-                                    <TableCell align="right" sx={{ backgroundColor: isDarkMode ? '#333' : 'inherit' }}></TableCell>
+                                    <TableCell sx={{ backgroundColor: isDarkMode ? '#333' : 'inherit', color: isDarkMode ? 'white' : 'inherit', fontWeight: 'bold' }}>
+                                        Date
+                                    </TableCell>
+                                    <TableCell sx={{ backgroundColor: isDarkMode ? '#333' : 'inherit', color: isDarkMode ? 'white' : 'inherit', fontWeight: 'bold' }}>
+                                        Location
+                                    </TableCell>
+                                    <TableCell sx={{ backgroundColor: isDarkMode ? '#333' : 'inherit', color: isDarkMode ? 'white' : 'inherit', fontWeight: 'bold' }}>
+                                        Host
+                                    </TableCell>
+                                    <TableCell sx={{ backgroundColor: isDarkMode ? '#333' : 'inherit', color: isDarkMode ? 'white' : 'inherit', fontWeight: 'bold' }}>
+                                        Contact
+                                    </TableCell>
+                                    <TableCell align="right" sx={{ backgroundColor: isDarkMode ? '#333' : 'inherit' }}>
+                                        Actions
+                                    </TableCell>
                                 </TableRow>
                             </TableHead>
                             <TableBody>
-                                {events.map((nscEvent) => (
-                                    <TableRow key={nscEvent.id}>
-                                        <TableCell>
-                                        </TableCell>
-                                        <TableCell component="th" scope="row">{nscEvent.eventTitle}</TableCell>
-                                        <TableCell>{nscEvent.startDate}</TableCell>
-                                        <TableCell>{nscEvent.eventLocation}</TableCell>
-                                        <TableCell>{nscEvent.eventContact}</TableCell>
-                                        <TableCell align="right">
-                                            <IconButton
-                                                aria-label="more"
-                                                id="long-button"
-                                                aria-controls={open ? 'long-menu' : undefined}
-                                                aria-expanded={open ? 'true' : undefined}
-                                                aria-haspopup="true"
-                                                onClick={handleClick}
-                                            >
-                                                <MoreVertIcon />
-                                            </IconButton>
-                                            <Menu
-                                                id="long-menu"
-                                                MenuListProps={{
-                                                    'aria-labelledby': 'long-button',
-                                                }}
-                                                anchorEl={anchorEl}
-                                                open={open}
-                                                onClose={handleClose}
-                                                slotProps={{
-                                                    paper: { style: { maxHeight: ITEM_HEIGHT * 4.5, width: '20ch', }, }, }}
-                                            >
-                                                {options.map((option) => (
-                                                    <MenuItem key={option} selected={option === 'place'} onClick={handleClose}>
-                                                        {option}
-                                                    </MenuItem>
-                                                ))}
-                                            </Menu>
+                                {events.length === 0 ? (
+                                    <TableRow>
+                                        <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+                                            <Typography variant="body1" color="text.secondary">
+                                                No archived events found
+                                            </Typography>
                                         </TableCell>
                                     </TableRow>
-                                ))}
+                                ) : (
+                                    events.map((event) => (
+                                        <TableRow key={event.id} hover>
+                                            <TableCell>{event.eventTitle}</TableCell>
+                                            <TableCell>
+                                                {new Date(event.startDate).toLocaleDateString()}
+                                            </TableCell>
+                                            <TableCell>{event.eventLocation}</TableCell>
+                                            <TableCell>{event.eventHost}</TableCell>
+                                            <TableCell>{event.eventContact}</TableCell>
+                                            <TableCell align="right">
+                                                <IconButton
+                                                    onClick={(e: React.MouseEvent<HTMLElement>) => handleMenuClick(e, event)}
+                                                    size="small"
+                                                >
+                                                    <MoreVertIcon />
+                                                </IconButton>
+                                            </TableCell>
+                                        </TableRow>
+                                    ))
+                                )}
                             </TableBody>
                         </Table>
                     </TableContainer>
-                </Grid>
-                <Stack alignSelf={"center"}>
-                    <Pagination
-                        color="primary"
-                        page={page}
-                        onChange={handleChange}
-                        count={10}
-                        showFirstButton
-                        showLastButton
-                        variant="outlined"
-                        shape="rounded"
-                        size="large"
-                        sx={{ padding: "2rem" }}/>
-                </Stack>
-            </Grid>
-        );
-    }
-    } else {
-        return <UnauthorizedPageMessage />;
-    }
-}
+
+                    {/* Pagination */}
+                    {events.length > 0 && (
+                        <Stack alignItems="center" mt={3}>
+                            <Pagination
+                                color="primary"
+                                page={page}
+                                onChange={handlePageChange}
+                                count={totalPages}
+                                showFirstButton
+                                showLastButton
+                                variant="outlined"
+                                shape="rounded"
+                                size="large"
+                            />
+                        </Stack>
+                    )}
+                </>
+            )}
+
+            {/* Action Menu */}
+            <Menu
+                anchorEl={anchorEl}
+                open={Boolean(anchorEl)}
+                onClose={handleMenuClose}
+            >
+                <MenuItem onClick={handleViewDetails}>View Details</MenuItem>
+                <MenuItem onClick={handleUnarchive}>Unarchive</MenuItem>
+            </Menu>
+
+            {/* Dialogs */}
+            {selectedEvent && (
+                <ArchiveDialog
+                    isOpen={archiveDialogOpen}
+                    event={selectedEvent}
+                    dialogToggle={() => {
+                        setArchiveDialogOpen(false);
+                        setSelectedEvent(null);
+                        fetchEvents(); // Refresh the list
+                    }}
+                />
+            )}
+        </Container>
+    );
+};
 
 export default ArchivedEvents;
-
-

--- a/nsc-events-nextjs/tests/unit/archivedEvents.test.tsx
+++ b/nsc-events-nextjs/tests/unit/archivedEvents.test.tsx
@@ -1,29 +1,89 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import ArchivedEvents from '@/app/archived-events/page';
 import useAuth from '@/hooks/useAuth';
-import { useArchivedEvents } from '@/utility/queries';
 import '@testing-library/jest-dom';
+import { useRouter } from 'next/navigation';
 
 jest.mock('@/hooks/useAuth');
-jest.mock('@/utility/queries');
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
 jest.mock('@/components/UnauthorizedPageMessage', () => () => <div>Unauthorized</div>);
+jest.mock('@/components/EventCard', () => ({ event }: any) => (
+  <div data-testid={`event-${event.id}`}>{event.eventTitle}</div>
+));
+jest.mock('@/components/ArchiveDialog', () => () => <div>Archive Dialog</div>);
+
+// Mock Material UI components that might cause issues
+jest.mock('@mui/material', () => ({
+  ...jest.requireActual('@mui/material'),
+  useTheme: () => ({
+    palette: { mode: 'light' },
+    breakpoints: {
+      between: () => '',
+      up: () => '',
+      down: () => '',
+      only: () => '',
+      not: () => '',
+      values: {
+        xs: 0,
+        sm: 600,
+        md: 900,
+        lg: 1200,
+        xl: 1536,
+      },
+    },
+  }),
+  useMediaQuery: () => false, // Default to desktop view
+}));
 
 describe('ArchivedEvents Page', () => {
-  beforeEach(() => {
-    // Mock `useAuth` to simulate an authorized user
-    (useAuth as jest.Mock).mockReturnValue({ isAuth: true, user: { role: 'admin' } });
+  const mockPush = jest.fn();
+  const mockRefresh = jest.fn();
 
-    // Mock `useArchivedEvents` to return test data
-    (useArchivedEvents as jest.Mock).mockReturnValue({
-      data: [
-        { id: '1', eventTitle: 'Archived Event 1', eventDate: '2024-11-15' },
-        { id: '2', eventTitle: 'Archived Event 2', eventDate: '2024-12-01' },
-      ],
-      isLoading: false,
-      isError: false,
-      error: null,
-      refetch: jest.fn(),
+  beforeEach(() => {
+    // Clear all mocks before each test
+    jest.clearAllMocks();
+
+    // Mock router
+    (useRouter as jest.Mock).mockReturnValue({
+      push: mockPush,
+      refresh: mockRefresh,
     });
+
+    // Mock fetch for API calls
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: async () => [
+          {
+            id: '1',
+            eventTitle: 'Archived Event 1',
+            startDate: '2024-11-15',
+            eventLocation: 'Seattle',
+            eventHost: 'NSC',
+            eventContact: 'test@example.com',
+            isArchived: true,
+          },
+          {
+            id: '2',
+            eventTitle: 'Archived Event 2',
+            startDate: '2024-12-01',
+            eventLocation: 'Tacoma',
+            eventHost: 'NSC',
+            eventContact: 'test2@example.com',
+            isArchived: true,
+          },
+        ],
+      }),
+    ) as jest.Mock;
+
+    // Set environment variable
+    process.env.NSC_EVENTS_PUBLIC_API_URL = 'http://localhost:3000/api';
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('renders UnauthorizedPageMessage if the user is not authorized', () => {
@@ -32,17 +92,50 @@ describe('ArchivedEvents Page', () => {
     expect(screen.getByText('Unauthorized')).toBeInTheDocument();
   });
 
-  it('renders the list of archived events for authorized users', () => {
+  it('renders UnauthorizedPageMessage if the user is not admin or creator', () => {
+    (useAuth as jest.Mock).mockReturnValue({ isAuth: true, user: { role: 'user' } });
     render(<ArchivedEvents />);
-    expect(screen.getByText('Archived Events')).toBeInTheDocument();
-    expect(screen.getByText('Archived Event 1')).toBeInTheDocument();
-    expect(screen.getByText('Archived Event 2')).toBeInTheDocument();
+    expect(screen.getByText('Unauthorized')).toBeInTheDocument();
   });
 
-  // Remove or adjust this test if not applicable
-  it('does not render "Load more events" button', () => {
+  it('renders the archived events page for admin users', async () => {
+    (useAuth as jest.Mock).mockReturnValue({ isAuth: true, user: { role: 'admin' } });
+
     render(<ArchivedEvents />);
-    const loadMoreButton = screen.queryByRole('button', { name: /load more events/i });
-    expect(loadMoreButton).not.toBeInTheDocument();
+
+    // Check for page title
+    expect(screen.getByText('Archived Events')).toBeInTheDocument();
+
+    // Wait for events to load
+    await waitFor(() => {
+      expect(screen.getByText('Archived Event 1')).toBeInTheDocument();
+      expect(screen.getByText('Archived Event 2')).toBeInTheDocument();
+    });
+  });
+
+  it('renders the archived events page for creator users', async () => {
+    (useAuth as jest.Mock).mockReturnValue({ isAuth: true, user: { role: 'creator' } });
+
+    render(<ArchivedEvents />);
+
+    // Check for page title
+    expect(screen.getByText('Archived Events')).toBeInTheDocument();
+
+    // Wait for events to load
+    await waitFor(() => {
+      expect(screen.getByText('Archived Event 1')).toBeInTheDocument();
+    });
+  });
+
+  it('fetches archived events with correct parameters', async () => {
+    (useAuth as jest.Mock).mockReturnValue({ isAuth: true, user: { role: 'admin' } });
+
+    render(<ArchivedEvents />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('isArchived=true'),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary & Changes 📃
- **Resolves:** #94
- **Resolves:** #113

- **Summary:** Implement archive/unarchive event flow with advanced search
  and filtering
  
    - 🔨 **What does this fix?**
    
      - No unarchive functionality (events couldn't be restored)
      - Search not implemented on archived events page
      - Missing location, host, and date range filters
      - Non-functional menu actions and hardcoded pagination
    - 👀 **What is the expected behavior?**
    
      - Bidirectional archive/unarchive with proper API endpoints
      - Full-text search across archived events (title, description, location, host)
      - Advanced filtering by location, host, and date range
      - Functional menu actions (View Details, Unarchive)
      - Dynamic pagination based on actual results
    - 🗨️ **Technical details:**
    
      - Backend: New unarchive endpoint, enhanced search with filters, comprehensive tests
      - Frontend: Complete rebuild of archived events page with debounced search, responsive
  design (desktop table + mobile infinite scroll)
      - Test coverage: 8 new backend tests, 5 updated frontend tests

- **Changes:**
    - ✅ **Backend (NestJS):**
    
      - Added `PUT /events/unarchive/:id` endpoint with authorization
      - Added `GET /events/search` with filters (isArchived, location, host, startDate, endDate)
      - Enhanced `GET /events` with location, host, and date range filters
      - Added `unarchiveActivity()` service method
      - Enhanced `searchActivities()` to support archived events and advanced filters
      - Added 8 comprehensive tests (unarchive + search filters)
      
    - ✅ **Frontend (Next.js):**
      - Updated `ArchiveDialog.tsx` for proper archive/unarchive toggle with dynamic endpoints
      - Complete rebuild of `app/archived-events/page.tsx`:
        - Debounced search (500ms) across title, description, location, host
        - Location and host filters with partial matching
        - Date range filters (start/end date)
        - Functional menu actions (View Details, Unarchive)
        - Dynamic pagination (desktop) and infinite scroll (mobile)
        - Loading states and empty states
        - Proper fetch-based data fetching (no longer using useArchivedEvents hook)
      - Updated `archivedEvents.test.tsx` with proper mocks for router, theme, and fetch
      
    - 🛠️ **No breaking changes** - All changes are additive and backward compatible


## Screenshots / Visual Aids 🔎

<details>
  <summary> Expand ⬇️ </summary>
 

https://github.com/user-attachments/assets/e75382c8-9915-47df-ad20-50f8a73dc921


</details>


## How to Test 🧪
  1. **Steps to Test Archive/Unarchive:**
     - Step 1: Log in as admin or creator
     - Step 2: Navigate to an active event and archive it
     - Step 3: Go to `/archived-events` and verify it appears
     - Step 4: Click the menu (⋮) and select "Unarchive"
     - Step 5: Verify success message and event returns to home page

  2. **Steps to Test Search & Filters:**
     - Step 1: Navigate to `/archived-events`
     - Step 2: Enter search term in search box (e.g., "workshop")
     - Step 3: Verify results filter in real-time (500ms debounce)
     - Step 4: Add location filter (e.g., "Seattle")
     - Step 5: Add host filter (e.g., "NSC")
     - Step 6: Add date range filters
     - Step 7: Verify all filters work together
     - Step 8: Click "Clear All Filters" to reset

  3. **Expected Behavior:**
     - Archive: Event disappears from home, appears in archived
     - Unarchive: Event removed from archived, appears on home
     - Search: Real-time filtering with 500ms debounce
     - Filters: All filters work independently and combined
     - Pagination: Desktop shows page numbers, mobile shows "Load More"
     - Mobile: Infinite scroll appends results
     - Desktop: Pagination replaces results


## Checklist ✅

- [X] I have **tested** this PR **locally** and it works as expected.
- [X] This PR **resolves an issue** (`Resolves #issue-number`).
- [X] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [ ] **Squash commits** and enable **auto-merge** if approved.

