### PR TITLE
Revise Git hooks setup instructions in HUSKY-UPDATE-HOOK.md

### DIFF
--- a/HUSKY-UPDATE-HOOK.md
+++ b/HUSKY-UPDATE-HOOK.md
@@ -1,4 +1,15 @@
 # Git Hooks Setup After `git pull`
+## For brand new Project clones:
+
+If you're setting up the project for the first time:
+
+1. Clone the repository
+2. Run `bash ./setup-macos-linux.sh` or `./setup-windows.bat` depending on your OS. 
+3. **That's it!** The `prepare` script automatically sets up Husky
+
+The hooks will work immediately with no additional steps needed!
+
+---
 
 ## If you already have this project locally and just ran `git pull origin main`:
 
@@ -11,20 +22,27 @@ You need to **remove old legacy hooks** that conflict with the new Husky v9 setu
 ```bash
 rm -f .git/hooks/pre-commit .git/hooks/pre-push
 ```
+Then run ```npm install``` in the root project directory
+
+---
 
 #### **Windows (PowerShell):**
 
 ```powershell
 Remove-Item .git/hooks/pre-commit, .git/hooks/pre-push -ErrorAction SilentlyContinue
 ```
+Then run ```npm install``` in the root project directory
+
+---
 
 #### **Windows (Command Prompt):**
 
 ```cmd
 del .git\hooks\pre-commit .git\hooks\pre-push
 ```
+Then run ```npm install``` in the root project directory
 
-**That's it!** After removing the old hooks, the new smart hooks will work automatically.
+**That's it!** After `removing the old hooks` and runing `npm install`, the new smart hooks will work automatically.
 
 ---
 
@@ -75,12 +93,4 @@ This creates legacy hooks that override Husky's smart detection and will run red
 
 ---
 
-## For brand new Project clones:
 
-If you're setting up the project for the first time:
-
-1. Clone the repository
-2. Run `bash ./setup-macos-linux.sh` or `./setup-windows.bat` depending on your OS. 
-3. **That's it!** The `prepare` script automatically sets up Husky
-
-The hooks will work immediately with no additional steps needed!


### PR DESCRIPTION
Updated instructions for setting up Git hooks after pulling changes, including cleanup steps for existing hooks and installation commands. 


<!-- Please use the following format for the title:-->
<!-- <repo>_<sprint#>_<issue#>_<PR-title> -->

<!-- Example: appdev-repo_88_888_example-pr-name -->

<!-- Please fill out the following: -->
## Summary & Changes 📃
- **Resolves:** #120 

- **Summary:** (Briefly describe what this PR does)
  - 🔨 What does this issue fix?
     - Adds `npm install` instruction after old hook removal
  - 👀 What is the expected behavior?
     - Now developers know that they will need to run `npm install` after removing the legacy husky hook only if they're not cloning a fresh repository of the project. 
  - 🗨️ Any relevant technical details?

- **Changes:**
  - ✅ List key changes made
  - 🛠️ Mention breaking changes (if any)
  - 🔗 Link relevant discussions/issues
  - 📝 Additional info to assist developers & reviewers


## Screenshots / Visual Aids 🔎
<sub><i>📌 **Required for:** UI changes, layout updates, or bug fixes.</i></sub>

<details>
  <summary> Expand ⬇️ </summary>
  <!-- add GIFs/Screenshots/Videos/Diagrams here -->
</details>


## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: ...
   - Step 2: ...
2. **Expected Behavior:** (Describe what should happen)
3. **Actual Behavior (if bug):** (Describe what happens instead)


## Checklist ✅

- [x] I have **tested** this PR **locally** and it works as expected.
- [x] This PR **resolves an issue** (`Resolves #issue-number`).
- [x] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [ ] **Squash commits** and enable **auto-merge** if approved.

