### PR TITLE
chore: update project-status.yml types to include forked repos

### DIFF
--- a/.github/workflows/project-status.yml
+++ b/.github/workflows/project-status.yml
@@ -3,7 +3,7 @@ name: Sync Project Status
 on:
   issues:
     types: [opened, assigned, closed, reopened]
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, converted_to_draft, closed, reopened]
   pull_request_review:
     types: [submitted]


### PR DESCRIPTION
Edge case discovered with workflow script.

Forked repos triggering a failure.

pull_request -> pull_request_target

This trigger runs in the context of the base repository, so it has access to secrets even for fork PRs

no testing needed
