### PR TITLE
nsc-events-fullstack_32_180-update-event-registration-endpoints

### DIFF
--- a/nsc-events-nestjs/src/event-registration/controllers/event-registration.controller.ts
+++ b/nsc-events-nestjs/src/event-registration/controllers/event-registration.controller.ts
@@ -15,6 +15,8 @@ import { EventRegistrationService } from '../services/event-registration.service
 import { CreateEventRegistrationDto } from '../dto/create-event-registration.dto';
 import { AttendEventDto } from '../dto/attend-event.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RoleGuard } from '../../auth/role.guard';
+import { Roles } from '../../auth/roles.decorator';
 import { EventRegistration } from '../entities/event-registration.entity';
 import { ActivityService } from '../../activity/services/activity/activity.service';
 import {
@@ -61,6 +63,8 @@ export class EventRegistrationController {
   }
 
   // New endpoint for attending an event
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
   @Post('attend')
   @ApiOperation({
     summary: 'Attend an event',
@@ -73,6 +77,7 @@ export class EventRegistrationController {
     type: EventRegistration,
   })
   @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 500, description: 'Error attending event' })
   async attendEvent(
     @Body() attendDto: AttendEventDto,
@@ -420,10 +425,13 @@ export class EventRegistrationController {
     return this.registrationService.markAttendance(id, body.isAttended);
   }
 
-  // Get attendees for an event
+  // Get attendees for an event (admin/creator only)
+  @Roles('admin', 'creator')
+  @UseGuards(JwtAuthGuard, RoleGuard)
+  @ApiBearerAuth('JWT-auth')
   @Get('attendees/:activityId')
   @ApiOperation({
-    summary: 'Get event attendees',
+    summary: 'Get event attendees (Admin/Creator only)',
     description:
       'Retrieves all attendees who have marked attendance for an event',
   })
@@ -433,6 +441,11 @@ export class EventRegistrationController {
     description: 'List of attendees',
     type: [EventRegistration],
   })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden - Admin/Creator role required',
+  })
   @ApiResponse({ status: 404, description: 'Event not found' })
   async getAttendeesForEvent(
     @Param('activityId') activityId: string,
@@ -440,10 +453,13 @@ export class EventRegistrationController {
     return this.registrationService.getAttendeesForActivity(activityId);
   }
 
-  // Get registration statistics for an event
+  // Get registration statistics for an event (admin/creator only)
+  @Roles('admin', 'creator')
+  @UseGuards(JwtAuthGuard, RoleGuard)
+  @ApiBearerAuth('JWT-auth')
   @Get('stats/:activityId')
   @ApiOperation({
-    summary: 'Get registration statistics',
+    summary: 'Get registration statistics (Admin/Creator only)',
     description:
       'Retrieves registration and attendance statistics for an event',
   })
@@ -459,6 +475,11 @@ export class EventRegistrationController {
         attendanceRate: { type: 'number', example: 0.9 },
       },
     },
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden - Admin/Creator role required',
   })
   @ApiResponse({ status: 404, description: 'Event not found' })
   async getRegistrationStats(@Param('activityId') activityId: string): Promise<{


### PR DESCRIPTION
## Summary & Changes 📃
- **Resolves:** #180

- **Summary:** (Briefly describe what this PR does)
  - 🔨 Fixes security vulnerability where sensitive endpoints had no authentication, allowing unauthenticated users to register for
  events and view attendee data
    - 👀 Users must now be authenticated to attend events; only admins/creators can access attendee lists and statistics
    - 🗨️ Uses existing JwtAuthGuard and RoleGuard patterns already established in the codebase
  - Changes:
    - ✅ Added JwtAuthGuard to POST /attend endpoint
    - ✅ Added JwtAuthGuard + RoleGuard with @Roles('admin', 'creator') to GET /attendees/:activityId
    - ✅ Added JwtAuthGuard + RoleGuard with @Roles('admin', 'creator') to GET /stats/:activityId
    - ✅ Updated Swagger documentation with 401/403 response codes
    - 🛠️ Breaking change: Frontend must now include JWT token for /attend requests

  How to Test 🧪

1. Steps to Reproduce:
    - Step 1: Start the backend server (npm run start:dev)
    - Step 2: Try POST /event-registration/attend without a JWT token → should return 401
    - Step 3: Try GET /event-registration/attendees/:activityId with a regular user token → should return 403
    - Step 4: Try the same endpoint with an admin/creator token → should return 200
2. Expected Behavior: Unauthenticated requests return 401; non-admin/creator users get 403 on restricted endpoints
3. Actual Behavior (before fix): All endpoints returned 200 without any authentication

## Checklist ✅

- [x] I have **tested** this PR **locally** and it works as expected.
- [x] This PR **resolves an issue** (`Resolves #issue-number`).
- [x] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [ ] **Squash commits** and enable **auto-merge** if approved.