### PR TITLE
nsc-events-fullstack_32_183-disable-swagger-api-doc-in-prod

### DIFF
--- a/nsc-events-nestjs/src/main.ts
+++ b/nsc-events-nestjs/src/main.ts
@@ -26,44 +26,50 @@ async function bootstrap() {
     exposedHeaders: ['Content-Length', 'Content-Type'],
   });
 
-  // Swagger configuration
-  const config = new DocumentBuilder()
-    .setTitle('NSC Events API')
-    .setDescription('API documentation for NSC Events management system')
-    .setVersion('2.0.0')
-    .addBearerAuth(
-      {
-        type: 'http',
-        scheme: 'bearer',
-        bearerFormat: 'JWT',
-        name: 'JWT',
-        description: 'Enter JWT token',
-        in: 'header',
-      },
-      'JWT-auth',
-    )
-    .addTag('Authentication', 'User authentication and authorization endpoints')
-    .addTag('Users', 'User management endpoints')
-    .addTag('Events', 'Event/Activity management endpoints')
-    .addTag('Event Registration', 'Event registration and attendance endpoints')
-    .addTag('Google Auth', 'Google Calendar integration endpoints')
-    .build();
+  // Swagger configuration - only enable in non-production environments
+  const isProduction = process.env.NODE_ENV === 'production';
 
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api/docs', app, document, {
-    swaggerOptions: {
-      persistAuthorization: true,
-      tagsSorter: 'alpha',
-      operationsSorter: 'alpha',
-    },
-    customSiteTitle: 'NSC Events API Documentation',
-  });
+  if (!isProduction) {
+    const config = new DocumentBuilder()
+      .setTitle('NSC Events API')
+      .setDescription('API documentation for NSC Events management system')
+      .setVersion('2.0.0')
+      .addBearerAuth(
+        {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          name: 'JWT',
+          description: 'Enter JWT token',
+          in: 'header',
+        },
+        'JWT-auth',
+      )
+      .addTag('Authentication', 'User authentication and authorization endpoints')
+      .addTag('Users', 'User management endpoints')
+      .addTag('Events', 'Event/Activity management endpoints')
+      .addTag('Event Registration', 'Event registration and attendance endpoints')
+      .addTag('Google Auth', 'Google Calendar integration endpoints')
+      .build();
+
+    const document = SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('api/docs', app, document, {
+      swaggerOptions: {
+        persistAuthorization: true,
+        tagsSorter: 'alpha',
+        operationsSorter: 'alpha',
+      },
+      customSiteTitle: 'NSC Events API Documentation',
+    });
+  }
 
   const port = process.env.PORT || 3000;
   await app.listen(port);
   console.log(`Application is running on: http://localhost:${port}/api`);
-  console.log(
-    `API Documentation available at: http://localhost:${port}/api/docs`,
-  );
+  if (!isProduction) {
+    console.log(
+      `API Documentation available at: http://localhost:${port}/api/docs`,
+    );
+  }
 }
 bootstrap();


### PR DESCRIPTION
## Summary & Changes 📃
- **Resolves:** #183

- **Summary:** Conditionally disable Swagger API documentation in production environments
  - 🔨 Fixes security vulnerability where /api/docs exposes all
  API endpoints, schemas, and authentication mechanisms in
  production
    - 👀 Swagger docs are only available in non-production
  environments (development, test); production returns 404
    - 🗨️ Uses NODE_ENV environment variable check - when set to
  production, Swagger setup is skipped entirely
  - Changes:
    - ✅ Wrapped Swagger configuration in main.ts with NODE_ENV !==
   'production' check
    - ✅ Console log for docs URL also conditionally shown only in
  non-production
    - 🛠️ No breaking changes - production behavior secured,
  development workflow unchanged
    - 📝 Ensure NODE_ENV=production is set in production deployment
   environment


  How to Test 🧪

  1. Steps to Reproduce:
    - Step 1: Run app with NODE_ENV=development → visit /api/docs
    - Step 2: Run app with NODE_ENV=production → visit /api/docs
  2. Expected Behavior:
    - Development: Swagger UI loads normally
    - Production: Returns 404 (route not found)
  3. Actual Behavior (if bug): Previously, Swagger was accessible
  in all environments

## Checklist ✅

- [x] I have **tested** this PR **locally** and it works as expected.
- [x] This PR **resolves an issue** (`Resolves #issue-number`).
- [x] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [ ] **Squash commits** and enable **auto-merge** if approved.